### PR TITLE
distro_features_check instead of features_check

### DIFF
--- a/recipes-eda/opencascade/opencascade.bb
+++ b/recipes-eda/opencascade/opencascade.bb
@@ -15,7 +15,7 @@ DEPENDS = " \
     vtk \
 "
 
-inherit cmake features_check
+inherit cmake distro_features_check
 
 REQUIRED_DISTRO_FEATURES = "opengl x11"
 

--- a/recipes-graphics/vtk/vtk.bb
+++ b/recipes-graphics/vtk/vtk.bb
@@ -2,7 +2,7 @@ SUMMARY = "The Visualization Toolkit"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://Copyright.txt;md5=074efbe58f4b7cbec2a2f6e6bdcb31e1"
 
-inherit cmake qemu python3native features_check
+inherit cmake qemu python3native distro_features_check
 REQUIRED_DISTRO_FEATURES = "opengl x11"
 
 SRC_URI = " \


### PR DESCRIPTION
This layer only depends on core and openembedded-layer. Neither of these have a class `features_check` on zeus. Core has distro_features_check which does what is intended here.