### PR TITLE
Add scarthgap to compatible releases

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -17,4 +17,4 @@ BBFILE_PRIORITY_meta-microcontroller = "10"
 LICENSE_PATH += "${LAYERDIR}/files/licenses"
 
 LAYERDEPENDS_meta-microcontroller = "core openembedded-layer meta-python"
-LAYERSERIES_COMPAT_meta-microcontroller = "honister kirkstone langdale"
+LAYERSERIES_COMPAT_meta-microcontroller = "honister kirkstone langdale scarthgap"


### PR DESCRIPTION
Tested by compiling code for ATmega32U4. `bitbake mc-fw` from https://github.com/prusa3d/Prusa-Firmware-SL1/blob/master/sources/meta-prusa/recipes-firmware/mc-fw/mc-fw_git.bb