### PR TITLE
Add nativesdk support to some avr tools

### DIFF
--- a/recipes-avr/avr-binutils/avr-binutils_2.38.bb
+++ b/recipes-avr/avr-binutils/avr-binutils_2.38.bb
@@ -23,7 +23,7 @@ SRC_URI[sha256sum] = "e316477a914f567eccc34d5d29785b8b0f5a10208d36bbacedcc39048e
 
 S = "${WORKDIR}/binutils-${PV}"
 
-BBCLASSEXTEND = "native"
+BBCLASSEXTEND = "native nativesdk"
 
 DEPENDS += "zlib"
 

--- a/recipes-avr/avr-gcc/avr-gcc_8.4.0.bb
+++ b/recipes-avr/avr-gcc/avr-gcc_8.4.0.bb
@@ -13,7 +13,7 @@ LIC_FILES_CHKSUM = "\
 
 inherit autotools gettext texinfo
 
-BBCLASSEXTEND = "native"
+BBCLASSEXTEND = "native nativesdk"
 
 DEPENDS = " \
     flex-native \
@@ -25,6 +25,7 @@ DEPENDS = " \
     libmpc \
 "
 DEPENDS:append:class-target = " ${BPN}-native"
+DEPENDS:append:class-nativesdk = " ${BPN}-native"
 
 PE = "1"
 

--- a/recipes-avr/avr-libc/avr-libc.bb
+++ b/recipes-avr/avr-libc/avr-libc.bb
@@ -2,5 +2,7 @@ require ${BPN}.inc
 
 inherit allarch
 
+BBCLASSEXTEND = "nativesdk"
+
 # Although we ship libraries this is allarch
 INSANE_SKIP:${PN} = "arch"

--- a/recipes-avr/packagegroups/nativesdk-packagegroup-avr-toolchain.bb
+++ b/recipes-avr/packagegroups/nativesdk-packagegroup-avr-toolchain.bb
@@ -1,0 +1,12 @@
+SUMMARY = "Packages for the avr-gcc toolchain in a stanalone SDK"
+LICENSE = "MIT"
+
+inherit packagegroup
+
+PACKAGEGROUP_DISABLE_COMPLEMENTARY = "1"
+
+RDEPENDS:${PN} += " \
+    nativesdk-avr-gcc \
+    nativesdk-avr-binutils \
+    nativesdk-avr-libc \
+    "


### PR DESCRIPTION
This pull request adds nativesdk support to the following tools:

- avr-gcc
- avr-binutils
- avr-libc

These tools can be included using the `nativesdk-packagegroup-avr-toolchain` within the `TOOLCHAIN_HOST_TASK` variable.

As I only needed these tools I didn't put any efford into making other avr-* tools nativesdk compatible. For avr-gdb I also stumbled upon some build errors and let it go at that.